### PR TITLE
fix: Swap wallet generation approval radio button labels

### DIFF
--- a/src/app/pages/poc-enterprise/enterprise-onboarding/add/add.component.html
+++ b/src/app/pages/poc-enterprise/enterprise-onboarding/add/add.component.html
@@ -123,8 +123,8 @@
                   formControlName="generateWallet"
                   nzName="radiogroup"
                 >
-                  <label nz-radio nzValue="0">Approval Required </label>
-                  <label nz-radio nzValue="1">No Approval Required </label>
+                  <label nz-radio nzValue="1">Approval Required </label>
+                  <label nz-radio nzValue="0">No Approval Required </label>
                 </nz-radio-group>
               </div>
             </div>


### PR DESCRIPTION
- Corrected radio button label order for wallet generation approval
- Swapped the labels to match the corresponding radio button values